### PR TITLE
Fixing TTL and Max_TTL Setting in Config Endpoint

### DIFF
--- a/path_config.go
+++ b/path_config.go
@@ -22,6 +22,14 @@ func pathConfig(b *backend) *framework.Path {
 				Default: "https://circleci.com",
 				Description: "The base URL used to construct all endpoint URLs for this plugin.",
 			},
+			"ttl": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: "Duration of the token's lifetime, unless renewed.",
+			},
+			"max_ttl": &framework.FieldSchema{
+				Type: framework.TypeString,
+				Description: "Maximum duration of the token's lifetime.",
+			},
 		},
 		Callbacks: map[logical.Operation]framework.OperationFunc{
 			logical.ReadOperation: b.pathConfigRead,
@@ -86,7 +94,10 @@ func (b *backend) pathConfigWrite(req *logical.Request, d *framework.FieldData) 
 	return nil, nil
 }
 
-func parseDurationField(fieldName string, d *framework.FieldData) (value time.Duration, err error) {
+func parseDurationField(fieldName string, d *framework.FieldData) (time.Duration, error) {
+	var value time.Duration
+	var err error
+
 	raw, ok := d.GetOk(fieldName)
 	if !ok || len(raw.(string)) == 0 {
 		value = 0
@@ -94,7 +105,7 @@ func parseDurationField(fieldName string, d *framework.FieldData) (value time.Du
 		value, err = time.ParseDuration(raw.(string))
 	}
 
-	return
+	return value, err
 }
 
 // Config reads the config object out of the provided Storage.

--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ GOOS=linux GOARCH=amd64 go build -o vault-circleci-auth-plugin
 
 docker rm -f vault || true
 
-docker run -d -e VAULT_ADDR=http://127.0.0.1:8200 -e VAULT_LOCAL_CONFIG='{"plugin_directory": "/vault/plugins"}' -v $PWD/vault-circleci-auth-plugin:/vault/plugins/vault-circleci-auth-plugin --name=vault vault:0.9.2 server -dev -dev-root-token-id=root
+docker run -d -e VAULT_ADDR=http://127.0.0.1:8200 -e VAULT_LOCAL_CONFIG='{"plugin_directory": "/vault/plugins"}' -v $PWD/vault-circleci-auth-plugin:/vault/plugins/vault-circleci-auth-plugin --name=vault vault:0.9.2 server -dev -dev-root-token-id=root -log-level=trace
 
 docker exec vault vault login root
 


### PR DESCRIPTION
This change fixes Issue #6.

Added the missing 'ttl' and 'max_ttl' fields to the path specification.

This change also modified the `run.sh` script to set trace level logging in the Vault server.