### PR TITLE
Restricting Login Endpoint to One Attempt per Build

### DIFF
--- a/build_list.go
+++ b/build_list.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"container/heap"
+	"time"
+)
+
+var exists = struct{}{}
+
+// CircleCIBuildList is a list that holds build identifiers sorted by time.
+type CircleCIBuildList struct {
+	projects map[string]map[int]struct{}
+
+	buildTimes BuildHeap
+}
+
+// New ...
+func New() *CircleCIBuildList {
+	return &CircleCIBuildList{
+		projects:   make(map[string]map[int]struct{}),
+		buildTimes: BuildHeap{},
+	}
+}
+
+// Add attempts to add a build record and returns true if there was no matching record,
+// otherwise false is returned.
+func (p *CircleCIBuildList) Add(project string, buildNum int) bool {
+	if _, ok := p.projects[project]; !ok {
+		p.projects[project] = make(map[int]struct{})
+	}
+
+	if _, ok := p.projects[project][buildNum]; ok {
+		return false
+	}
+
+	p.projects[project][buildNum] = exists
+
+	build := CircleCIBuild{
+		time:     time.Now(),
+		project:  project,
+		buildNum: buildNum,
+	}
+
+	heap.Push(&p.buildTimes, build)
+
+	return true
+}
+
+// Cleanup removes all build records recorded prior to t.
+func (p *CircleCIBuildList) Cleanup(t time.Time) {
+	if len(p.buildTimes) > 0 {
+		b := heap.Pop(&p.buildTimes).(CircleCIBuild)
+
+		for b.time.Before(t) {
+			if _, ok := p.projects[b.project]; ok {
+				delete(p.projects[b.project], b.buildNum)
+
+				if len(p.projects[b.project]) == 0 {
+					delete(p.projects, b.project)
+				}
+			}
+
+			if len(p.buildTimes) > 0 {
+				b = heap.Pop(&p.buildTimes).(CircleCIBuild)
+			} else {
+				return
+			}
+		}
+
+		heap.Push(&p.buildTimes, b)
+	}
+}
+
+func (p *CircleCIBuildList) size() int {
+	return p.buildTimes.Len()
+}
+
+// BuildHeap ...
+type BuildHeap []CircleCIBuild
+
+// CircleCIBuild ...
+type CircleCIBuild struct {
+	time     time.Time
+	project  string
+	buildNum int
+}
+
+func (h BuildHeap) Less(i, j int) bool {
+	return h[i].time.Before(h[j].time)
+}
+
+func (h BuildHeap) Len() int {
+	return len(h)
+}
+
+func (h BuildHeap) Swap(i, j int) {
+	h[i], h[j] = h[j], h[i]
+}
+
+// Push ...
+func (h *BuildHeap) Push(x interface{}) {
+	*h = append(*h, x.(CircleCIBuild))
+}
+
+// Pop ...
+func (h *BuildHeap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}

--- a/build_list_test.go
+++ b/build_list_test.go
@@ -68,10 +68,10 @@ func TestCleanup(t *testing.T) {
 
 	now := time.Now()
 
-	l.Cleanup(now.Add(-time.Hour))
+	l.Cleanup(now.Add(-time.Hour), nil)
 	assert.Equal(t, len(data), l.size())
 
-	l.Cleanup(now.Add(time.Hour))
+	l.Cleanup(now.Add(time.Hour), nil)
 	assert.Equal(t, 0, l.size())
 
 	for _, d := range data {
@@ -86,6 +86,6 @@ func TestCleanup(t *testing.T) {
 		l.Add(d.project, d.buildNum)
 	}
 
-	l.Cleanup(now)
+	l.Cleanup(now, nil)
 	assert.Equal(t, len(data2), l.size())
 }

--- a/build_list_test.go
+++ b/build_list_test.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAdd(t *testing.T) {
+	l := New()
+
+	assert.True(t, l.Add("proj1", 1))
+	assert.False(t, l.Add("proj1", 1))
+	assert.True(t, l.Add("proj1", 2))
+	assert.True(t, l.Add("proj1", 4))
+	assert.True(t, l.Add("proj1", 3))
+
+	assert.True(t, l.Add("proj2", 1))
+}
+
+func TestCleanup(t *testing.T) {
+	l := New()
+
+	data := []struct {
+		project  string
+		buildNum int
+	}{
+		{
+			project:  "proj1",
+			buildNum: 5,
+		},
+		{
+			project:  "proj1",
+			buildNum: 6,
+		},
+		{
+			project:  "proj2",
+			buildNum: 3,
+		},
+		{
+			project:  "proj2",
+			buildNum: 4,
+		},
+		{
+			project:  "proj4",
+			buildNum: 10,
+		},
+	}
+
+	data2 := []struct {
+		project  string
+		buildNum int
+	}{
+		{
+			project:  "later1",
+			buildNum: 11,
+		},
+		{
+			project:  "proj2",
+			buildNum: 7,
+		},
+	}
+
+	for _, d := range data {
+		l.Add(d.project, d.buildNum)
+	}
+
+	now := time.Now()
+
+	l.Cleanup(now.Add(-time.Hour))
+	assert.Equal(t, len(data), l.size())
+
+	l.Cleanup(now.Add(time.Hour))
+	assert.Equal(t, 0, l.size())
+
+	for _, d := range data {
+		l.Add(d.project, d.buildNum)
+	}
+
+	now = time.Now()
+
+	time.Sleep(time.Second)
+
+	for _, d := range data2 {
+		l.Add(d.project, d.buildNum)
+	}
+
+	l.Cleanup(now)
+	assert.Equal(t, len(data2), l.size())
+}

--- a/integration-test/tests.sh
+++ b/integration-test/tests.sh
@@ -54,7 +54,8 @@ echo -n "Creating docker container for vault: "
 docker create --rm --name vault --network vaulttest \
         -e VAULT_TOKEN=root -e VAULT_ADDR=http://127.0.0.1:8200 \
         -e VAULT_LOCAL_CONFIG='{"plugin_directory": "/vault/plugins/"}' \
-        vault:0.9.2 server -dev -dev-root-token-id=root
+        vault:0.9.2 server -dev -dev-root-token-id=root \
+        -log-level trace
 docker cp plugins vault:/vault/
 echo -n "Starting docker container " ; docker start vault
 
@@ -83,3 +84,10 @@ for i in 1 2 3 4 5; do
                 && echo "Test $i PASSED"
     fi
 done
+
+# Testing a second attempt at authenticating the same build
+read response <<< $(docker exec vault vault write auth/test5/login project=someproject build_num=100 \
+        vcs_revision=babababababababababababababababababababa 2>&1)
+
+echo $response | grep -F "an attempt to authenticate as this build has already been made" > /dev/null \
+        && echo "Test $i-supplement PASSED"

--- a/integration-test/tests.sh
+++ b/integration-test/tests.sh
@@ -55,7 +55,7 @@ docker create --rm --name vault --network vaulttest \
         -e VAULT_TOKEN=root -e VAULT_ADDR=http://127.0.0.1:8200 \
         -e VAULT_LOCAL_CONFIG='{"plugin_directory": "/vault/plugins/"}' \
         vault:0.9.2 server -dev -dev-root-token-id=root \
-        -log-level trace
+        ${VAULT_LOG_LEVEL:-""}
 docker cp plugins vault:/vault/
 echo -n "Starting docker container " ; docker start vault
 
@@ -90,4 +90,28 @@ read response <<< $(docker exec vault vault write auth/test5/login project=somep
         vcs_revision=babababababababababababababababababababa 2>&1)
 
 echo $response | grep -F "an attempt to authenticate as this build has already been made" > /dev/null \
-        && echo "Test $i-supplement PASSED"
+        && echo "Test 6 PASSED"
+
+docker exec vault vault write auth/test5/config circleci_token=fake \
+            vcs_type=github owner=johnsmith ttl=5m max_ttl=15m \
+            base_url=http://circle$i:7979 attempt_cache_time=1s
+
+echo "Waiting 90 seconds so that Attempts cache can be cleared..."
+sleep 90s
+
+# This test verifies the ability to adjust the time that records are
+# kept in the attempts cache, by reducing that period to 1 second
+# and verifying that another login attempt can be made, which proves that
+# the attempts cache has been cleared.  Adjusting this duration would be
+# done for 2 reasons:
+#   1. Increased, if there are concerns that a CircleCI build could
+#      still be running after 5 hours (will increase memory consumption)
+#   2. Decreased, if operators want to reduce memory consumption and
+#      they are certain that build lifetimes won't exceed the new
+#      duration.
+read response <<< $(docker exec vault vault write -format=json \
+        auth/test3/login project=someproject build_num=100 \
+        vcs_revision=babababababababababababababababababababa 2>&1)
+
+[[ $(echo $response | jq -r '.auth.client_token' | wc -c) -gt 0 ]] \
+        && echo "Test 7 PASSED"


### PR DESCRIPTION
This PR adds code that only allows a single attempt to call the `/auth/circleci/login` endpoint for any given build (combination of project name and build number), within an instance of the plugin backend.

The rationale for this restriction is to reduce the window of opportunity for an attacker to impersonate a CircleCI build by submitting a valid request while the given CircleCI build is still running.  With this change, only the first request will succeed (if all input parameters were valid and the build is still running), and all subsequent requests will result in an error (HTTP 400 with a message indicating that an attempt was already made for the specified build).

The plugin's backend automatically removes records of builds that are older than the `attempts_cache_time` configuration parameter.  The default value is 5 hours based on the fact that this appears to be the maximum duration of CircleCI builds.

The plugin restricts the `auth/circleci/login` to a single attempt.  The plugin does not differentiate between failed attempts and successful attempts.